### PR TITLE
Filter on property and multi channel support

### DIFF
--- a/HowToUse.md
+++ b/HowToUse.md
@@ -34,7 +34,7 @@ It's possible to send messages for multiple channels based on the value
 of a property for the event.
 
 |Parameter|Meaning|Default value|
-|-|-|-|-|
+|-|-|-|
 |filterOnProperty|Send **only** the events that have a property with this name.|`null`|
 |channelList|Mapping for the target channels Uri and the filter property value. If the filter property for the event is not on this list, the webHookUri will be used|`null`|
 

--- a/HowToUse.md
+++ b/HowToUse.md
@@ -26,6 +26,69 @@ The project can be found on [nuget](https://www.nuget.org/packages/Serilog.Sinks
 |buttons|Option to add static clickable buttons to each message.|`buttons: new[] { new MicrosoftTeamsSinkOptionsButton("Google", "https://google.de") }`|`null`|
 |failureCallback|Adds an option to add a failure callback action.|`failureCallback: e => Console.WriteLine($"Sink error: {e.Message}")`|`null`|
 |queueLimit|The maximum number of events that should be stored in the batching queue.|`queueLimit: 10`|`int.MaxValue` or `2147483647`|
+|channelHandler|Configuration for dispatching events to multiple channels.|See [Support for multiple channels](#support-for-multiple-channels)|`null`|
+
+### Support for multiple channels
+
+It's possible to send messages for multiple channels based on the value
+of a property for the event.
+
+|Parameter|Meaning|Default value|
+|-|-|-|-|
+|filterOnProperty|Send **only** the events that have a property with this name.|`null`|
+|channelList|Mapping for the target channels Uri and the filter property value. If the filter property for the event is not on this list, the webHookUri will be used|`null`|
+
+Example configuration:
+
+```json
+{
+    "Serilog": {
+        "Using": [ "Serilog.Sinks.MicrosoftTeams.Alternative" ],
+        "MinimumLevel": "Debug",
+        "WriteTo": [
+            {
+                "Name": "MicrosoftTeams",
+                "Args": {
+                    "webHookUri": "http://example.com/",
+                    "channelHandler":
+                    {
+                        "filterOnProperty": "MsTeams",
+                        "channelList": {
+                            "ITTeam": "http://example.com/ITTeam/",
+                            "SupportTeam": "http://example.com/SupportTeam/"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}
+```
+
+> **Note**: filterOnProperty can be used with an empty channelList to send
+> only some log events to Teams.
+
+#### Adding the required property for filterOnProperty to events
+
+Once filterOnProperty is set, some events will need to be marked to be sent
+to Teams.
+
+Using Serilog:
+
+```csharp
+var loggerForChannel = logger.ForContext("filterOnPropertyValue", "ChannelName");
+loggerForChannel.Information("Hello");
+```
+
+Using Microsoft iLogger:
+
+```csharp
+using (logger.BeginScope(
+    new Dictionary<string, object> { ["filterOnPropertyValue"] = "ChannelName" }))
+{
+    logger.LogInformation("Hello");
+}
+```
 
 ## Further information
 This project is a fork of https://github.com/DixonDs/serilog-sinks-teams but is maintained.

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/Extensions/WireMockExtensions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/Extensions/WireMockExtensions.cs
@@ -1,0 +1,40 @@
+namespace Serilog.Sinks.MicrosoftTeams.Alternative.Tests.Extensions;
+
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+internal static class WireMockExtensions
+{
+    public static void AddDefaultChannel(this WireMockServer server)
+    {
+        server.Given(
+                Request
+                    .Create()
+                    .WithPath("/")
+                    .WithHeader("content-type", "application/json; charset=utf-8")
+                    .UsingPost()
+            )
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(200)
+            );
+    }
+
+    public static void AddChannel(this WireMockServer server, string channel)
+    {
+        server.Given(
+                Request
+                    .Create()
+                    .WithPath($"/{channel}/")
+                    .WithHeader("content-type", "application/json; charset=utf-8")
+                    .UsingPost()
+            )
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(200)
+            );
+    }
+}

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/MicrosoftTeamsSinkTest.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/MicrosoftTeamsSinkTest.cs
@@ -370,7 +370,7 @@ public class MicrosoftTeamsSinkTest
             Assert.AreEqual(
                 1,
                 mockServer.LogEntries.Count(t => t.RequestMessage.Url == channelPair.Value),
-                "Wrong event count for the default channel"
+                $"Wrong event count for the channel {channelPair.Key}"
             );
         }
 

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/MicrosoftTeamsSinkTest.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/MicrosoftTeamsSinkTest.cs
@@ -43,6 +43,7 @@ public class MicrosoftTeamsSinkTest
     [TestMethod]
     public void EmitMessagesWithAllLogEventLevels()
     {
+        using var mockServer = TestHelper.CreateMockServer();
         this.logger = TestHelper.CreateLogger();
 
         var counter = 0;
@@ -57,6 +58,18 @@ public class MicrosoftTeamsSinkTest
 
         Thread.Sleep(1000);
         Log.CloseAndFlush();
+
+        Assert.IsTrue(
+            mockServer
+                .LogEntries
+                .All(t => t.PartialMatchResult.IsPerfectMatch),
+            "Invalid requests made to the mock server"
+        );
+
+        Assert.AreEqual(
+            6,
+            mockServer.LogEntries.Count(),
+            "Wrong number of events send to teams");
     }
 
     /// <summary>
@@ -65,10 +78,23 @@ public class MicrosoftTeamsSinkTest
     [TestMethod]
     public void EmitMessagesWithOmittedProperties()
     {
+        using var mockServer = TestHelper.CreateMockServer();
         this.logger = TestHelper.CreateLogger(true);
         this.logger.Debug("Message text {prop}", 4);
         Thread.Sleep(1000);
         Log.CloseAndFlush();
+
+        Assert.IsTrue(
+            mockServer
+                .LogEntries
+                .All(t => t.PartialMatchResult.IsPerfectMatch),
+            "Invalid requests made to the mock server"
+        );
+
+        Assert.AreEqual(
+            1,
+            mockServer.LogEntries.Count(),
+            "Wrong number of events send to teams");
     }
 
     /// <summary>
@@ -77,10 +103,23 @@ public class MicrosoftTeamsSinkTest
     [TestMethod]
     public void EmitMessagesWithZeroButtons()
     {
+        using var mockServer = TestHelper.CreateMockServer();
         this.logger = TestHelper.CreateLoggerWithButtons(this.buttons.Take(0));
         this.logger.Debug("Message text {prop}", 1);
         Thread.Sleep(1000);
         Log.CloseAndFlush();
+
+        Assert.IsTrue(
+            mockServer
+                .LogEntries
+                .All(t => t.PartialMatchResult.IsPerfectMatch),
+            "Invalid requests made to the mock server"
+        );
+
+        Assert.AreEqual(
+            1,
+            mockServer.LogEntries.Count(),
+            "Wrong number of events send to teams");
     }
 
     /// <summary>
@@ -89,10 +128,23 @@ public class MicrosoftTeamsSinkTest
     [TestMethod]
     public void EmitMessagesWithOneButton()
     {
+        using var mockServer = TestHelper.CreateMockServer();
         this.logger = TestHelper.CreateLoggerWithButtons(this.buttons.Take(1));
         this.logger.Debug("Message text {prop}", 2);
         Thread.Sleep(1000);
         Log.CloseAndFlush();
+
+        Assert.IsTrue(
+            mockServer
+                .LogEntries
+                .All(t => t.PartialMatchResult.IsPerfectMatch),
+            "Invalid requests made to the mock server"
+        );
+
+        Assert.AreEqual(
+            1,
+            mockServer.LogEntries.Count(),
+            "Wrong number of events send to teams");
     }
 
     /// <summary>
@@ -101,10 +153,23 @@ public class MicrosoftTeamsSinkTest
     [TestMethod]
     public void EmitMessagesWithTwoButtons()
     {
+        using var mockServer = TestHelper.CreateMockServer();
         this.logger = TestHelper.CreateLoggerWithButtons(this.buttons.Take(2));
         this.logger.Debug("Message text {prop}", 3);
         Thread.Sleep(1000);
         Log.CloseAndFlush();
+
+        Assert.IsTrue(
+            mockServer
+                .LogEntries
+                .All(t => t.PartialMatchResult.IsPerfectMatch),
+            "Invalid requests made to the mock server"
+        );
+
+        Assert.AreEqual(
+            1,
+            mockServer.LogEntries.Count(),
+            "Wrong number of events send to teams");
     }
 
     /// <summary>
@@ -114,6 +179,7 @@ public class MicrosoftTeamsSinkTest
     [TestMethod]
     public void EmitMessagesWithComplexData()
     {
+        using var mockServer = TestHelper.CreateMockServer();
         this.logger = TestHelper.CreateLoggerWithCodeTags();
         var data = File.ReadAllText("TestException.txt");
         this.logger.Debug(data);
@@ -127,10 +193,23 @@ public class MicrosoftTeamsSinkTest
     [TestMethod]
     public void EmitMessagesWithTitleTemplate()
     {
+        using var mockServer = TestHelper.CreateMockServer();
         this.logger = TestHelper.CreateLogger("My title: {Tenant}");
         this.logger.Debug("Message text {prop} for tenant {Tenant}", 1, "Tenant1");
         Thread.Sleep(1000);
         Log.CloseAndFlush();
+
+        Assert.IsTrue(
+            mockServer
+                .LogEntries
+                .All(t => t.PartialMatchResult.IsPerfectMatch),
+            "Invalid requests made to the mock server"
+        );
+
+        Assert.AreEqual(
+            1,
+            mockServer.LogEntries.Count(),
+            "Wrong number of events send to teams");
     }
 
     /// <summary>

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/MicrosoftTeamsSinkTest.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/MicrosoftTeamsSinkTest.cs
@@ -71,7 +71,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             6,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             1,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -121,7 +121,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             1,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -146,7 +146,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             1,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -171,7 +171,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             1,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -211,7 +211,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             1,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -264,7 +264,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             logLevels.Length,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -310,7 +310,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             1,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -377,7 +377,7 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             channelDictionary.Count + 1,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 
     /// <summary>
@@ -423,6 +423,6 @@ public class MicrosoftTeamsSinkTest
         Assert.AreEqual(
             1,
             mockServer.LogEntries.Count(),
-            "Wrong number of events send to teams");
+            "Wrong number of events sent to teams");
     }
 }

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/Serilog.Sinks.MicrosoftTeams.Alternative.Tests.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/Serilog.Sinks.MicrosoftTeams.Alternative.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -7,6 +7,12 @@
 	<Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.TwoChannelsExample.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.9.0">
@@ -20,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="WireMock.Net" Version="1.4.40" />
   </ItemGroup>
 

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/Serilog.Sinks.MicrosoftTeams.Alternative.Tests.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/Serilog.Sinks.MicrosoftTeams.Alternative.Tests.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="WireMock.Net" Version="1.4.40" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/TestHelper.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/TestHelper.cs
@@ -9,15 +9,24 @@
 
 namespace Serilog.Sinks.MicrosoftTeams.Alternative.Tests;
 
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
 /// <summary>
 /// A helper class for the tests.
 /// </summary>
 public static class TestHelper
 {
     /// <summary>
+    /// The default port for the mock http server
+    /// </summary>
+    private static readonly int MockServerPort = 63210;
+
+    /// <summary>
     /// The test web hook URL.
     /// </summary>
-    private static readonly string TestWebHook = Environment.GetEnvironmentVariable("MicrosoftTeamsWebhookUrl") ?? string.Empty;
+    private static readonly string TestWebHook = Environment.GetEnvironmentVariable("MicrosoftTeamsWebhookUrl") ?? $"http://localhost:{MockServerPort}";
 
     /// <summary>
     /// Creates the logger.
@@ -76,5 +85,44 @@ public static class TestHelper
             .CreateLogger();
 
         return logger;
+    }
+
+    /// <summary>
+    /// Creates the logger with a channel handler.
+    /// </summary>
+    /// <param name="channelHandler">Channel handler</param>
+    /// <returns>An <see cref="ILogger"/>.</returns>
+    public static ILogger CreateLoggerWithChannels(MicrosoftTeamsSinkChannelHandlerOptions channelHandler)
+    {
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.MicrosoftTeams(new MicrosoftTeamsSinkOptions(TestWebHook, channelHandler: channelHandler))
+            .CreateLogger();
+
+        return logger;
+    }
+
+    /// <summary>
+    /// Creates a mock http server
+    /// </summary>
+    /// <returns>A mocked server</returns>
+    public static WireMockServer CreateMockServer()
+    {
+        var server = WireMockServer.Start(MockServerPort);
+
+        server.Given(
+                Request
+                    .Create()
+                    .WithPath("/")
+                    .WithHeader("content-type", "application/json; charset=utf-8")
+                    .UsingPost()
+            )
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(200)
+            );
+        
+        return server;
     }
 }

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/TestHelper.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/TestHelper.cs
@@ -10,8 +10,7 @@
 namespace Serilog.Sinks.MicrosoftTeams.Alternative.Tests;
 
 using Extensions;
-using WireMock.RequestBuilders;
-using WireMock.ResponseBuilders;
+using Microsoft.Extensions.Configuration;
 using WireMock.Server;
 
 /// <summary>
@@ -98,6 +97,25 @@ public static class TestHelper
         var logger = new LoggerConfiguration()
             .MinimumLevel.Verbose()
             .WriteTo.MicrosoftTeams(new MicrosoftTeamsSinkOptions(TestWebHook, channelHandler: channelHandler))
+            .CreateLogger();
+
+        return logger;
+    }
+
+    /// <summary>
+    /// Creates the logger from a appsettings file
+    /// </summary>
+    /// <param name="appsettingsPath">Path for the appsettings file to use</param>
+    /// <returns>An <see cref="ILogger"/>.</returns>
+    public static ILogger CreateLoggerFromConfiguration(string appsettingsPath)
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile(appsettingsPath)
+            .Build();
+
+        var logger = new LoggerConfiguration()
+            .ReadFrom.Configuration(configuration)
             .CreateLogger();
 
         return logger;

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/TestHelper.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/TestHelper.cs
@@ -9,6 +9,7 @@
 
 namespace Serilog.Sinks.MicrosoftTeams.Alternative.Tests;
 
+using Extensions;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -103,26 +104,25 @@ public static class TestHelper
     }
 
     /// <summary>
-    /// Creates a mock http server
+    /// Creates a mock http server with the default channel
+    /// </summary>
+    /// <returns>A mocked server</returns>
+    public static WireMockServer CreateMockServerWithDefaultChannel()
+    {
+        var server = WireMockServer.Start(MockServerPort);
+        server.AddDefaultChannel();
+
+        return server;
+    }
+
+    /// <summary>
+    /// Creates a clean mock http server
     /// </summary>
     /// <returns>A mocked server</returns>
     public static WireMockServer CreateMockServer()
     {
         var server = WireMockServer.Start(MockServerPort);
 
-        server.Given(
-                Request
-                    .Create()
-                    .WithPath("/")
-                    .WithHeader("content-type", "application/json; charset=utf-8")
-                    .UsingPost()
-            )
-            .RespondWith(
-                Response
-                    .Create()
-                    .WithStatusCode(200)
-            );
-        
         return server;
     }
 }

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/appsettings.TwoChannelsExample.json
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/appsettings.TwoChannelsExample.json
@@ -1,0 +1,22 @@
+{
+    "Serilog": {
+        "Using": [ "Serilog.Sinks.MicrosoftTeams.Alternative" ],
+        "MinimumLevel": "Debug",
+        "WriteTo": [
+            {
+                "Name": "MicrosoftTeams",
+                "Args": {
+                    "webHookUri": "http://localhost:63210/",
+                    "channelHandler":
+                    {
+                        "filterOnProperty": "MsTeams",
+                        "channelList": {
+                            "ITTeam": "http://localhost:63210/ITTeam/",
+                            "SupportTeam": "http://localhost:63210/SupportTeam/"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/LoggerConfigurationMicrosoftTeamsExtensions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/LoggerConfigurationMicrosoftTeamsExtensions.cs
@@ -40,6 +40,7 @@ public static class LoggerConfigurationMicrosoftTeamsExtensions
     /// <param name="buttons">The buttons to add to a message.</param>
     /// <param name="failureCallback">The failure callback.</param>
     /// <param name="queueLimit">The maximum number of events that should be stored in the batching queue.</param>
+    /// <param name="channelHandler">The configuration for sending events to multiple channels</param>
     /// <returns>Instance of <see cref="LoggerConfiguration"/> object.</returns>
     public static LoggerConfiguration MicrosoftTeams(
         this LoggerSinkConfiguration loggerSinkConfiguration,
@@ -55,7 +56,8 @@ public static class LoggerConfigurationMicrosoftTeamsExtensions
         bool useCodeTagsForMessage = false,
         IEnumerable<MicrosoftTeamsSinkOptionsButton>? buttons = null,
         Action<Exception>? failureCallback = null,
-        int? queueLimit = null)
+        int? queueLimit = null,
+        MicrosoftTeamsSinkChannelHandlerOptions? channelHandler = null)
     {
         var microsoftTeamsSinkOptions = new MicrosoftTeamsSinkOptions(
             webHookUri,
@@ -70,7 +72,8 @@ public static class LoggerConfigurationMicrosoftTeamsExtensions
             proxy,
             buttons,
             failureCallback,
-            queueLimit);
+            queueLimit,
+            channelHandler);
         return loggerSinkConfiguration.MicrosoftTeams(microsoftTeamsSinkOptions, restrictedToMinimumLevel);
     }
 

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSink.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSink.cs
@@ -105,9 +105,10 @@ public class MicrosoftTeamsSink : IBatchedLogEventSink
     /// <returns>A <see cref="List{T}"/> of <see cref="MicrosoftExtendedLogEvent"/>.</returns>
     private IEnumerable<MicrosoftExtendedLogEvent> GetMessagesToSend(IEnumerable<LogEvent> events)
     {
+        var filteredEvents = this.FilterEventsByProperty(events);
         var messagesToSend = new List<MicrosoftExtendedLogEvent>();
 
-        foreach (var logEvent in events)
+        foreach (var logEvent in filteredEvents)
         {
             if (logEvent.Level < this.options.MinimumLogEventLevel)
             {
@@ -134,6 +135,22 @@ public class MicrosoftTeamsSink : IBatchedLogEventSink
         }
 
         return messagesToSend;
+    }
+
+    /// <summary>
+    /// Filter for the events with the configured property, if no filter is set returns all events
+    /// </summary>
+    /// <param name="events">Events to filter</param>
+    /// <returns>Filtered events</returns>
+    private IEnumerable<LogEvent> FilterEventsByProperty(IEnumerable<LogEvent> events)
+    {
+        if (!string.IsNullOrWhiteSpace(this.options.ChannelHandler?.FilterOnProperty))
+        {
+            return events.Where(t =>
+                t.Properties.ContainsKey(this.options.ChannelHandler?.FilterOnProperty));
+        }
+
+        return events;
     }
 
     /// <summary>

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkChannelHandlerOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkChannelHandlerOptions.cs
@@ -23,11 +23,17 @@ public class MicrosoftTeamsSinkChannelHandlerOptions
     ///     Mapping between a requested channel (set in <see cref="FilterOnProperty"/>) and it's api endpoint
     /// </summary>
     /// <example>
-    ///     If <see cref="FilterOnProperty"/> is set to "MsTeams" then the value of that property is
+    ///     If <see cref="FilterOnProperty"/> is set then the value of that property is
     ///     searched on this dictionary to find the matching channel endpoint, if no matching key is
     ///     found here, it will send the event to the default endpoint for this sink.
     /// </example>
-    public Dictionary<string, string>? ChannelList { get; }
+    public Dictionary<string, string> ChannelList { get; }
+
+    /// <summary>
+    /// Checks if the sink is configured to only emit events that have the property set in <see cref="FilterOnProperty"/>
+    /// </summary>
+    public bool GetIsFilterOnPropertyEnabled =>
+        !string.IsNullOrWhiteSpace(this.FilterOnProperty);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MicrosoftTeamsSinkChannelHandlerOptions"/> class.
@@ -37,6 +43,6 @@ public class MicrosoftTeamsSinkChannelHandlerOptions
     public MicrosoftTeamsSinkChannelHandlerOptions(string? filterOnProperty = null, Dictionary<string, string>? channelList = null)
     {
         this.FilterOnProperty = filterOnProperty;
-        this.ChannelList = channelList;
+        this.ChannelList = channelList ?? new Dictionary<string, string>();
     }
 }

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkChannelHandlerOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkChannelHandlerOptions.cs
@@ -1,0 +1,42 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MicrosoftTeamsSinkOptions.cs" company="SeppPenner and the Serilog contributors">
+// The project is licensed under the MIT license.
+// </copyright>
+// <summary>
+//   Container for the multiple channel configuration.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Serilog.Sinks.MicrosoftTeams.Alternative;
+
+/// <summary>
+/// Container for the multiple channel configuration
+/// </summary>
+public class MicrosoftTeamsSinkChannelHandlerOptions
+{
+    /// <summary>
+    ///     Only emit events that have this property (Ignoring it's value)
+    /// </summary>
+    public string? FilterOnProperty { get; }
+
+    /// <summary>
+    ///     Mapping between a requested channel (set in <see cref="FilterOnProperty"/>) and it's api endpoint
+    /// </summary>
+    /// <example>
+    ///     If <see cref="FilterOnProperty"/> is set to "MsTeams" then the value of that property is
+    ///     searched on this dictionary to find the matching channel endpoint, if no matching key is
+    ///     found here, it will send the event to the default endpoint for this sink.
+    /// </example>
+    public Dictionary<string, string>? ChannelList { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MicrosoftTeamsSinkChannelHandlerOptions"/> class.
+    /// </summary>
+    /// <param name="filterOnProperty">Only emit events that have this property (Ignoring it's value)</param>
+    /// <param name="channelList">Mapping between a requested channel (set in <see cref="FilterOnProperty"/>) and it's api endpoint</param>
+    public MicrosoftTeamsSinkChannelHandlerOptions(string? filterOnProperty = null, Dictionary<string, string>? channelList = null)
+    {
+        this.FilterOnProperty = filterOnProperty;
+        this.ChannelList = channelList;
+    }
+}

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkChannelHandlerOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkChannelHandlerOptions.cs
@@ -17,7 +17,7 @@ public class MicrosoftTeamsSinkChannelHandlerOptions
     /// <summary>
     ///     Only emit events that have this property (Ignoring it's value)
     /// </summary>
-    public string? FilterOnProperty { get; }
+    public string? FilterOnProperty { get; set; }
 
     /// <summary>
     ///     Mapping between a requested channel (set in <see cref="FilterOnProperty"/>) and it's api endpoint
@@ -27,7 +27,7 @@ public class MicrosoftTeamsSinkChannelHandlerOptions
     ///     searched on this dictionary to find the matching channel endpoint, if no matching key is
     ///     found here, it will send the event to the default endpoint for this sink.
     /// </example>
-    public Dictionary<string, string> ChannelList { get; }
+    public Dictionary<string, string> ChannelList { get; set; } = new ();
 
     /// <summary>
     /// Checks if the sink is configured to only emit events that have the property set in <see cref="FilterOnProperty"/>
@@ -44,5 +44,12 @@ public class MicrosoftTeamsSinkChannelHandlerOptions
     {
         this.FilterOnProperty = filterOnProperty;
         this.ChannelList = channelList ?? new Dictionary<string, string>();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MicrosoftTeamsSinkChannelHandlerOptions"/> class.
+    /// </summary>
+    public MicrosoftTeamsSinkChannelHandlerOptions()
+    {
     }
 }

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkOptions.cs
@@ -82,7 +82,7 @@ public class MicrosoftTeamsSinkOptions
         this.Buttons = buttons ?? new List<MicrosoftTeamsSinkOptionsButton>();
         this.FailureCallback = failureCallback;
         this.QueueLimit = queueLimit ?? DefaultQueueLimit;
-        this.ChannelHandler = channelHandler;
+        this.ChannelHandler = channelHandler ?? new MicrosoftTeamsSinkChannelHandlerOptions();
     }
 
     /// <summary>
@@ -153,5 +153,5 @@ public class MicrosoftTeamsSinkOptions
     /// <summary>
     /// Gets the configuration for sending events to multiple channels
     /// </summary>
-    public MicrosoftTeamsSinkChannelHandlerOptions? ChannelHandler { get; }
+    public MicrosoftTeamsSinkChannelHandlerOptions ChannelHandler { get; }
 }

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkOptions.cs
@@ -47,6 +47,7 @@ public class MicrosoftTeamsSinkOptions
     /// <param name="buttons">The buttons to add to a message.</param>
     /// <param name="failureCallback">The failure callback.</param>
     /// <param name="queueLimit">The maximum number of events that should be stored in the batching queue.</param>
+    /// <param name="channelHandler">The configuration for sending events to multiple channels</param>
     public MicrosoftTeamsSinkOptions(
         string webHookUri,
         string? titleTemplate = null,
@@ -60,13 +61,14 @@ public class MicrosoftTeamsSinkOptions
         string? proxy = null,
         IEnumerable<MicrosoftTeamsSinkOptionsButton>? buttons = null,
         Action<Exception>? failureCallback = null,
-        int? queueLimit = null)
+        int? queueLimit = null,
+        MicrosoftTeamsSinkChannelHandlerOptions? channelHandler = null)
     {
         if (string.IsNullOrWhiteSpace(webHookUri))
         {
             throw new ArgumentException("The webhook URI is empty.", nameof(webHookUri));
         }
-
+        
         this.WebHookUri = webHookUri;
         this.TitleTemplate = titleTemplate;
         this.BatchSizeLimit = batchSizeLimit ?? DefaultBatchSizeLimit;
@@ -80,6 +82,7 @@ public class MicrosoftTeamsSinkOptions
         this.Buttons = buttons ?? new List<MicrosoftTeamsSinkOptionsButton>();
         this.FailureCallback = failureCallback;
         this.QueueLimit = queueLimit ?? DefaultQueueLimit;
+        this.ChannelHandler = channelHandler;
     }
 
     /// <summary>
@@ -146,4 +149,9 @@ public class MicrosoftTeamsSinkOptions
     /// Gets the maximum number of events that should be stored in the batching queue.
     /// </summary>
     public int QueueLimit { get; }
+
+    /// <summary>
+    /// Gets the configuration for sending events to multiple channels
+    /// </summary>
+    public MicrosoftTeamsSinkChannelHandlerOptions? ChannelHandler { get; }
 }


### PR DESCRIPTION
# This PR will add support for:

* Only emit events that have a specific property
* Use that same property do choose to what channel the event should be sent

closes #22

## Notes

The new tests make use of WireMock to check for the actual sending of the messages, hope that is acceptable, the existing tests were adapted to do the same, but better validation of the message contents may be advisable.