### PR TITLE
Wrap exception into code block

### DIFF
--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSink.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSink.cs
@@ -293,7 +293,11 @@ public class MicrosoftTeamsSink : IBatchedLogEventSink
 
         if (logEvent.LogEvent.Exception != null)
         {
-            yield return new MicrosoftTeamsMessageFact { Name = "Exception", Value = logEvent.LogEvent.Exception.ToString() };
+            yield return new MicrosoftTeamsMessageFact
+            {
+                Name = "Exception",
+                Value = $"```{Environment.NewLine}{logEvent.LogEvent.Exception}{Environment.NewLine}```"
+            };
         }
 
         foreach (var property in logEvent.LogEvent.Properties)

--- a/src/Serilog.Sinks.MicrosoftTeams.Utf8Json/Sinks/MicrosoftTeams/Utf8Json/MicrosoftTeamsSink.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Utf8Json/Sinks/MicrosoftTeams/Utf8Json/MicrosoftTeamsSink.cs
@@ -254,7 +254,11 @@ public class MicrosoftTeamsSink : IBatchedLogEventSink
 
         if (logEvent.LogEvent.Exception != null)
         {
-            yield return new MicrosoftTeamsMessageFact { Name = "Exception", Value = logEvent.LogEvent.Exception.ToString() };
+            yield return new MicrosoftTeamsMessageFact
+            {
+                Name = "Exception",
+                Value = $"```{Environment.NewLine}{logEvent.LogEvent.Exception}{Environment.NewLine}```"
+            };
         }
 
         foreach (var property in logEvent.LogEvent.Properties)


### PR DESCRIPTION
When an exception contains a stack trace with generic classes inside, the greater-than and the lower-than sign are getting interpreted as format instructions which leads to some nasty formatted output.

This pr fixes it with wrapping the whole exception into a code block like the one used for `useCodeTagsForMessage`.