### PR TITLE
Fix to allow use of Teams Incoming Webhook using PowerAutomateWorkflow

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,6 @@
 Change history
 --------------
 
-* **Version 1.5.0.0 (2024-08-05)**: Add support to use Teams Power Automate Workflows via option flag, fix for https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative/issues/33.
 * **Version 1.4.7.0 (2024-06-04)**: Updated NuGet packages, fixes https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative/issues/32.
 * **Version 1.4.6.0 (2024-05-16)**: Removed support for Net7.0.
 * **Version 1.4.5.0 (2024-04-22)**: Updated NuGet packages, fixes https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative/issues/31.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 Change history
 --------------
 
+* **Version 1.5.0.0 (2024-08-05)**: Add support to use Teams Power Automate Workflows via option flag, fix for https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative/issues/33.
 * **Version 1.4.7.0 (2024-06-04)**: Updated NuGet packages, fixes https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative/issues/32.
 * **Version 1.4.6.0 (2024-05-16)**: Removed support for Net7.0.
 * **Version 1.4.5.0 (2024-04-22)**: Updated NuGet packages, fixes https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative/issues/31.

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/MicrosoftTeamsSinkTest.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/MicrosoftTeamsSinkTest.cs
@@ -483,4 +483,29 @@ public class MicrosoftTeamsSinkTest
             mockServer.LogEntries.Count(),
             "Wrong number of events sent to teams");
     }
+
+    /// <summary>
+    /// Tests the emitting of messages to the default channel when using power automate workflow
+    /// </summary>
+    [TestMethod]
+    public void EmitMessagesWithPowerAutomateWorkflow()
+    {
+        using var mockServer = TestHelper.CreateMockServerWithDefaultChannel();
+        this.logger = TestHelper.CreateLogger(false, true);
+        this.logger.Error("Message text {Property}", 4);
+        Thread.Sleep(2000);
+        Log.CloseAndFlush();
+
+        Assert.IsTrue(
+            mockServer
+                .LogEntries
+                .All(t => t.PartialMatchResult.IsPerfectMatch),
+            "Invalid requests made to the mock server"
+        );
+
+        Assert.AreEqual(
+            1,
+            mockServer.LogEntries.Count(),
+            "Wrong number of events sent to teams");
+    }
 }

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/TestHelper.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative.Tests/TestHelper.cs
@@ -43,12 +43,30 @@ public static class TestHelper
     /// Creates the logger.
     /// </summary>
     /// <param name="omitPropertiesSection">A value indicating whether the properties should be omitted or not.</param>
+    /// <param name="usePowerAutomateWorkflows">A value indicating wheather to use power automate workflow</param>
     /// <returns>An <see cref="ILogger"/>.</returns>
-    public static ILogger CreateLogger(bool omitPropertiesSection = false)
+    public static ILogger CreateLogger(bool omitPropertiesSection = false, bool usePowerAutomateWorkflows = false)
     {
         var logger = new LoggerConfiguration()
             .MinimumLevel.Verbose()
-            .WriteTo.MicrosoftTeams(new MicrosoftTeamsSinkOptions(TestWebHook, "Integration Tests", omitPropertiesSection: omitPropertiesSection))
+            .WriteTo.MicrosoftTeams(new MicrosoftTeamsSinkOptions(TestWebHook, "Integration Tests", omitPropertiesSection: omitPropertiesSection, usePowerAutomateWorkflows: usePowerAutomateWorkflows))
+            .CreateLogger();
+
+        return logger;
+    }
+
+    /// <summary>
+    /// Creates logger with Url
+    /// </summary>
+    /// <param name="url"></param>
+    /// <param name="omitPropertiesSection"></param>
+    /// <param name="usePowerAutomateWorkflows"></param>
+    /// <returns></returns>
+    public static ILogger CreateLoggerWithUrl(string url, bool omitPropertiesSection = false, bool usePowerAutomateWorkflows = false)
+    {
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.MicrosoftTeams(new MicrosoftTeamsSinkOptions(url, "Integration Tests", omitPropertiesSection: omitPropertiesSection, usePowerAutomateWorkflows: usePowerAutomateWorkflows))
             .CreateLogger();
 
         return logger;

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/LoggerConfigurationMicrosoftTeamsExtensions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/LoggerConfigurationMicrosoftTeamsExtensions.cs
@@ -37,6 +37,7 @@ public static class LoggerConfigurationMicrosoftTeamsExtensions
     /// <param name = "proxy" > The proxy address to use.</param>
     /// <param name="omitPropertiesSection">Indicates whether the properties section should be omitted or not.</param>
     /// <param name="useCodeTagsForMessage">A value indicating whether code tags are used for the message template or not.</param>
+    /// <param name="usePowerAutomateWorkflow">A value indicating whether to use power automate workflow when sending message or not.</param>
     /// <param name="buttons">The buttons to add to a message.</param>
     /// <param name="failureCallback">The failure callback.</param>
     /// <param name="queueLimit">The maximum number of events that should be stored in the batching queue.</param>
@@ -54,6 +55,7 @@ public static class LoggerConfigurationMicrosoftTeamsExtensions
         string? proxy = null,
         bool omitPropertiesSection = false,
         bool useCodeTagsForMessage = false,
+        bool usePowerAutomateWorkflow = false,
         IEnumerable<MicrosoftTeamsSinkOptionsButton>? buttons = null,
         Action<Exception>? failureCallback = null,
         int? queueLimit = null,
@@ -69,6 +71,7 @@ public static class LoggerConfigurationMicrosoftTeamsExtensions
             restrictedToMinimumLevel,
             omitPropertiesSection,
             useCodeTagsForMessage,
+            usePowerAutomateWorkflow,
             proxy,
             buttons,
             failureCallback,

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Serilog.Sinks.MicrosoftTeams.Alternative.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Serilog.Sinks.MicrosoftTeams.Alternative.csproj
@@ -31,6 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AdaptiveCards" Version="3.1.0" />
         <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Serilog.Sinks.MicrosoftTeams.Alternative.csproj
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Serilog.Sinks.MicrosoftTeams.Alternative.csproj
@@ -16,7 +16,7 @@
         <RepositoryUrl>https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative</RepositoryUrl>
         <PackageIcon>Icon.png</PackageIcon>
         <RepositoryType>Github</RepositoryType>
-        <PackageReleaseNotes>Version 1.4.7.0 (2024-06-04): Updated NuGet packages, fixes https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative/issues/32.</PackageReleaseNotes>
+        <PackageReleaseNotes>Version 1.4.8.0 (2024-08-27): Updated NuGet packages, fixes https://github.com/serilog-contrib/Serilog.Sinks.MicrosoftTeams.Alternative/issues/33. Add option to use PowerAutomate Workflow and update card JSON structure.</PackageReleaseNotes>
         <PackageLicenseFile>License.txt</PackageLicenseFile>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/Core/MicrosoftTeamsAttachment.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/Core/MicrosoftTeamsAttachment.cs
@@ -1,0 +1,30 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MicrosoftTeamsMessageCard.cs" company="SeppPenner and the Serilog contributors">
+// The project is licensed under the MIT license.
+// </copyright>
+// <summary>
+//   The teams message card.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Serilog.Sinks.MicrosoftTeams.Alternative.Core;
+
+/// <summary>
+/// The teams message card.
+/// </summary>
+internal class MicrosoftTeamsAttachment
+{
+    /// <summary>
+    /// Gets the type of the card.
+    /// </summary>
+    [JsonProperty("contentType")]
+    public string ContentType { get; } = "application/vnd.microsoft.card.adaptive";
+
+    [JsonProperty("contentUrl")]
+    public string ContentUrl { get; } = null!;
+
+    [JsonProperty("content")]
+    [JsonConverter(typeof(AdaptiveCards.AdaptiveCardConverter))]
+    public AdaptiveCards.AdaptiveCard Content { get; set; } = null!;
+    
+}

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/Core/MicrosoftTeamsMessage.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/Core/MicrosoftTeamsMessage.cs
@@ -1,0 +1,26 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MicrosoftTeamsMessageCard.cs" company="SeppPenner and the Serilog contributors">
+// The project is licensed under the MIT license.
+// </copyright>
+// <summary>
+//   The teams message card.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Serilog.Sinks.MicrosoftTeams.Alternative.Core;
+
+/// <summary>
+/// The teams message card.
+/// </summary>
+internal class MicrosoftTeamsMessage
+{
+    /// <summary>
+    /// Gets the type of the card.
+    /// </summary>
+    [JsonProperty("type")]
+    public string Type { get; } = "message";
+
+    [JsonProperty("attachments")]
+    public List<MicrosoftTeamsAttachment> Attachments { get; set; } = new List<MicrosoftTeamsAttachment>();
+    
+}

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkOptions.cs
@@ -134,7 +134,7 @@ public class MicrosoftTeamsSinkOptions
     public bool UseCodeTagsForMessage { get; }
 
     /// <summary>
-    /// Gets a value indicating wheather Power Automate workflows are used or not.
+    /// Gets a value indicating wheather Power Automate workflows are used or not. (since O365 Incoming Webhooks are being shutdown)
     /// </summary>
     public bool UsePowerAutomateWorkflows { get; }
 

--- a/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkOptions.cs
+++ b/src/Serilog.Sinks.MicrosoftTeams.Alternative/Sinks/MicrosoftTeams/Alternative/MicrosoftTeamsSinkOptions.cs
@@ -43,6 +43,7 @@ public class MicrosoftTeamsSinkOptions
     /// <param name="minimumLogEventLevel">The minimum log event level to use.</param>
     /// <param name="omitPropertiesSection">A value indicating whether the properties section should be omitted or not.</param>
     /// <param name="useCodeTagsForMessage">A value indicating whether code tags are used for the message template or not.</param>
+    /// <param name="usePowerAutomateWorkflows">A value indicating whether Power Automate workflows are used or not.</param>
     /// <param name="proxy">The proxy address to use.</param>
     /// <param name="buttons">The buttons to add to a message.</param>
     /// <param name="failureCallback">The failure callback.</param>
@@ -58,6 +59,7 @@ public class MicrosoftTeamsSinkOptions
         LogEventLevel minimumLogEventLevel = LogEventLevel.Verbose,
         bool omitPropertiesSection = false,
         bool useCodeTagsForMessage = false,
+        bool usePowerAutomateWorkflows = false,
         string? proxy = null,
         IEnumerable<MicrosoftTeamsSinkOptionsButton>? buttons = null,
         Action<Exception>? failureCallback = null,
@@ -78,6 +80,7 @@ public class MicrosoftTeamsSinkOptions
         this.MinimumLogEventLevel = minimumLogEventLevel;
         this.OmitPropertiesSection = omitPropertiesSection;
         this.UseCodeTagsForMessage = useCodeTagsForMessage;
+        this.UsePowerAutomateWorkflows = usePowerAutomateWorkflows;
         this.Proxy = proxy;
         this.Buttons = buttons ?? new List<MicrosoftTeamsSinkOptionsButton>();
         this.FailureCallback = failureCallback;
@@ -129,6 +132,11 @@ public class MicrosoftTeamsSinkOptions
     /// Gets a value indicating whether code tags are used for the message template or not.
     /// </summary>
     public bool UseCodeTagsForMessage { get; }
+
+    /// <summary>
+    /// Gets a value indicating wheather Power Automate workflows are used or not.
+    /// </summary>
+    public bool UsePowerAutomateWorkflows { get; }
 
     /// <summary>
     /// Gets the proxy URL.


### PR DESCRIPTION
As per Issue #33, needed support to use the newer Teams Incoming WebHook that uses the PowerAutomate Workflow approach. This PR add's additional option "UsePowerAutomateWorkflow" (default to false to not break existing usage). When option set to true, then will format using AdaptiveCards to serialize to required JSON format for the PowerAutomate Workflow.